### PR TITLE
Object stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,30 @@ Directly on `StreamArray` there is a class-level helper function `make()`, which
 
 The test file for `StreamArray`: `tests/test_array.js`.
 
+### utils/StreamObject
+
+Similar to `StreamArray`, except that instead of breaking an array into its elements it breaks an object into key/value pairs. Each pair has two properties: `key` and `value`.
+
+Like `StreamArray`, `StreamObject` is both a constructor and has a static `make()` function for common use cases.
+
+```js
+var StreamObject = require("stream-json/utils/StreamObject");
+var stream = StreamObject.make();
+
+// Example of use:
+
+stream.output.on("data", function(object){
+  console.log(object.key, object.value);
+});
+stream.output.on("end", function(){
+  console.log("done");
+});
+
+fs.createReadStream(fname).pipe(stream.input);
+```
+
+See the `StreamArray` documentation for more information.
+
 ### utils/StreamFilteredArray
 
 This utility handles the same use case as `StreamArray`, but in addition it allows to check the objects as they are being built to reject, or accept them. Rejected objects are not assembled, and filtered out.

--- a/tests/test_object.js
+++ b/tests/test_object.js
@@ -1,0 +1,58 @@
+"use strict";
+
+
+var unit = require("heya-unit");
+
+var ReadString  = require("./ReadString");
+var StreamObject = require("../utils/StreamObject");
+
+
+unit.add(module, [
+	function test_object_fail(t){
+		var async = t.startAsync("test_object_fail");
+
+		var stream = StreamObject.make();
+
+		stream.output.on("data", function(value){
+			eval(t.TEST("!'We shouldn\'t be here.'"));
+		});
+		stream.output.on("error", function(err){
+			eval(t.TEST("err"));
+			async.done();
+		});
+		stream.output.on("end", function(value){
+			eval(t.TEST("!'We shouldn\'t be here.'"));
+			async.done();
+		});
+
+		new ReadString(" true ").pipe(stream.input);
+	},
+	function test_object(t){
+		var async = t.startAsync("test_object");
+
+		var stream  = StreamObject.make(),
+			pattern = {
+				str: "bar",
+				baz: null,
+				t: true,
+				f: false,
+				zero: 0,
+				one: 1,
+				obj: {},
+				arr: [],
+				deepObj: {a: "b"},
+				deepArr: ["c"]
+			}
+			result = {};
+
+		stream.output.on("data", function(data){
+			result[data.key] = data.value;
+		});
+		stream.output.on("end", function(){
+			eval(t.TEST("t.unify(pattern, result)"));
+			async.done();
+		});
+
+		new ReadString(JSON.stringify(pattern)).pipe(stream.input);
+	}
+]);

--- a/utils/StreamObject.js
+++ b/utils/StreamObject.js
@@ -12,44 +12,44 @@ function StreamObject(options){
 
 	this._assembler = null;
 	this._isInitial = true;
-  this._depth = 0;
+	this._depth = 0;
 }
 util.inherits(StreamObject, Transform);
 
 StreamObject.prototype._transform = function transform(chunk, encoding, callback){
-  // first chunk should open an object
+	// first chunk should open an object
 	if(this._isInitial){
-    if(chunk.name !== "startObject") {
-      return callback(new Error("Top-level construct should be an object."));
-    }
-    this._assembler = new Assembler();
-    this._isInitial = false;
-  }
+		if(chunk.name !== "startObject") {
+			return callback(new Error("Top-level construct should be an object."));
+		}
+		this._assembler = new Assembler();
+		this._isInitial = false;
+	}
 
-  switch(chunk.name){
-    case 'startObject':
-    case 'startArray':
-      this._depth++;
-      break;
-    case 'endObject':
-    case 'endArray':
-      this._depth--;
-      break;
-    case 'keyValue':
-      if(this._depth === 1){
-        this._currentKey = chunk.value;
-      }
-      break;
-  }
+	switch(chunk.name){
+		case 'startObject':
+		case 'startArray':
+			this._depth++;
+			break;
+		case 'endObject':
+		case 'endArray':
+			this._depth--;
+			break;
+		case 'keyValue':
+			if(this._depth === 1){
+				this._currentKey = chunk.value;
+			}
+			break;
+	}
 
-  if(this._currentKey){
-    this._assembler[chunk.name] && this._assembler[chunk.name](chunk.value);
-  }
+	if(this._currentKey){
+		this._assembler[chunk.name] && this._assembler[chunk.name](chunk.value);
+	}
 
-  if(this._depth === 1 && this._assembler.current){
-    this.push({key: this._currentKey, value: this._assembler.current});
-    this._assembler.current = this._currentKey = null;
-  }
+	if(this._depth === 1 && this._assembler.current){
+		this.push({key: this._currentKey, value: this._assembler.current});
+		this._assembler.current = this._currentKey = null;
+	}
 
 	callback();
 };

--- a/utils/StreamObject.js
+++ b/utils/StreamObject.js
@@ -1,0 +1,74 @@
+"use strict";
+
+var util = require("util");
+var Transform = require("stream").Transform;
+var Assembler = require("./Assembler");
+var Combo = require("../Combo");
+
+function StreamObject(options){
+	Transform.call(this, options);
+	this._writableState.objectMode = true;
+	this._readableState.objectMode = true;
+
+	this._assembler = null;
+	this._isInitial = true;
+  this._depth = 0;
+}
+util.inherits(StreamObject, Transform);
+
+StreamObject.prototype._transform = function transform(chunk, encoding, callback){
+  // first chunk should open an object
+	if(this._isInitial){
+    if(chunk.name !== "startObject") {
+      return callback(new Error("Top-level construct should be an object."));
+    }
+    this._assembler = new Assembler();
+    this._isInitial = false;
+  }
+
+  switch(chunk.name){
+    case 'startObject':
+    case 'startArray':
+      this._depth++;
+      break;
+    case 'endObject':
+    case 'endArray':
+      this._depth--;
+      break;
+    case 'keyValue':
+      if(this._depth === 1){
+        this._currentKey = chunk.value;
+      }
+      break;
+  }
+
+  if(this._currentKey){
+    this._assembler[chunk.name] && this._assembler[chunk.name](chunk.value);
+  }
+
+  if(this._depth === 1 && this._assembler.current){
+    this.push({key: this._currentKey, value: this._assembler.current});
+    this._assembler.current = this._currentKey = null;
+  }
+
+	callback();
+};
+
+StreamObject.make = function make(options){
+	var o = options ? Object.create(options) : {};
+	o.packKeys = o.packStrings = o.packNumbers = true;
+
+	var streams = [new Combo(o), new StreamObject(options)];
+
+	// connect pipes
+	var input = streams[0], output = input;
+	streams.forEach(function(stream, index){
+		if(index){
+			output = output.pipe(stream);
+		}
+	});
+
+	return {streams: streams, input: input, output: output};
+};
+
+module.exports = StreamObject;

--- a/utils/StreamObject.js
+++ b/utils/StreamObject.js
@@ -27,15 +27,15 @@ StreamObject.prototype._transform = function transform(chunk, encoding, callback
 	}
 
 	switch(chunk.name){
-		case 'startObject':
-		case 'startArray':
+		case "startObject":
+		case "startArray":
 			this._depth++;
 			break;
-		case 'endObject':
-		case 'endArray':
+		case "endObject":
+		case "endArray":
 			this._depth--;
 			break;
-		case 'keyValue':
+		case "keyValue":
 			if(this._depth === 1){
 				this._currentKey = chunk.value;
 			}


### PR DESCRIPTION
This PR adds a utility class similar to StreamArray, except that instead of emitting indexes from an array it emits key/value pairs from an object. Thus for an object like this:

``` js
{
  "foo": "bar",
  "baz": [1, 2, 3]
}
```

You would get it nicely separated into chunks like this:

``` js
{ key: "foo", value: "bar" }
{ key: "baz", value: [1, 2, 3] }
```

Other than the different types being output, the interface is exactly the same as StreamArray, i.e. you can create one easily with `StreamObject.make(opts)`.