### PR TITLE
Feat/55

### DIFF
--- a/Parser.js
+++ b/Parser.js
@@ -81,6 +81,7 @@ class Parser extends Transform {
   _transform(chunk, _, callback) {
     this._buffer += chunk.toString();
     this._processInput(callback);
+    this.emit('boundary');
   }
 
   _flush(callback) {

--- a/filters/FilterBase.js
+++ b/filters/FilterBase.js
@@ -51,6 +51,16 @@ class FilterBase extends Transform {
     }
 
     this._once = options && options.once;
+    
+    let emitBoundary = () => {
+      this.emit('boundary');
+    };
+    this.on('pipe', (src) => {
+      src.on('boundary', emitBoundary);
+    });
+    this.on('unpipe', (src) => {
+      src.off('boundary', emitBoundary);
+    });
   }
 
   _check(chunk, _, callback) {

--- a/streamers/StreamBase.js
+++ b/streamers/StreamBase.js
@@ -31,6 +31,16 @@ class StreamBase extends Transform {
     }
     this._assembler = new Assembler();
     this._transform = this._wait || this._filter;
+
+    let emitBoundary = () => {
+      this.emit('boundary');
+    };
+    this.on('pipe', (src) => {
+      src.on('boundary', emitBoundary);
+    });
+    this.on('unpipe', (src) => {
+      src.off('boundary', emitBoundary);
+    });
   }
 
   _transform(chunk, encoding, callback) {

--- a/utils/Pulse.js
+++ b/utils/Pulse.js
@@ -17,8 +17,10 @@ class Pulse extends Transform {
     this._accumulator = [];
 
     let handleBoundary = () => {
-      this.push(this._accumulator);
-      this._accumulator = [];
+      if (this._accumulator.length) {
+        this.push(this._accumulator);
+        this._accumulator = [];
+      }
     };
     this.on('pipe', (src) => {
       src.on('boundary', handleBoundary);

--- a/utils/Pulse.js
+++ b/utils/Pulse.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const {Transform} = require('stream');
+const withParser = require('./withParser');
+
+class Pulse extends Transform {
+  static make(options) {
+    return new Pulse(options);
+  }
+
+  static withParser(options) {
+    return withParser(Pulse.make, options);
+  }
+
+  constructor(options) {
+    super(Object.assign({}, options, {writableObjectMode: true, readableObjectMode: true}));
+    this._accumulator = [];
+
+    let handleBoundary = () => {
+      this.push(this._accumulator);
+      this._accumulator = [];
+    };
+    this.on('pipe', (src) => {
+      src.on('boundary', handleBoundary);
+    });
+    this.on('unpipe', (src) => {
+      src.off('boundary', handleBoundary);
+    });
+  }
+
+  _transform(chunk, _, callback) {
+    this._accumulator.push(chunk);
+    callback(null);
+  }
+
+  _flush(callback) {
+    if (this._accumulator.length) {
+      this.push(this._accumulator);
+      this._accumulator = null;
+    }
+    callback(null);
+  }
+}
+Pulse.pulse = Pulse.make;
+Pulse.make.Constructor = Pulse;
+
+module.exports = Pulse;


### PR DESCRIPTION
Implements #55 

Simply forwards the `boundary` event thru Transforms to signify each time the input stream has emitted data and thus is about to occupy main thread (for file streams this includes performing IO).

`Pulse` util simply accumulates items until `boundary` event is emitted down the chain. This provides consumers with a single event with the batch of items that finished parsing during this chunk so they can dispatch workers with highest task concurrency balanced across threads.