### PR TITLE
feat: add the makeObject option for Stringer

### DIFF
--- a/Stringer.js
+++ b/Stringer.js
@@ -61,9 +61,14 @@ class Stringer extends Transform {
     this._prev = '';
     this._depth = 0;
 
-    if (this._makeArray) {
+    if (this._makeArray && this._makeObject) {
+      // todo: should it throw an error or not?
+    } else if (this._makeArray) {
       this._transform = this._arrayTransform;
       this._flush = this._arrayFlush;
+    } else if (this._makeObject) {
+      this._transform = this._objectTransform;
+      this._flush = this._objectFlush;
     }
   }
 
@@ -80,6 +85,21 @@ class Stringer extends Transform {
       this._transform({name: 'startArray'}, null, doNothing);
     }
     this._transform({name: 'endArray'}, null, callback);
+  }
+
+  _objectTransform(chunk, encoding, callback) {
+    // it runs once
+    delete this._transform;
+    this._transform({name: 'startObject'}, encoding, doNothing);
+    this._transform(chunk, encoding, callback);
+  }
+
+  _objectFlush(callback) {
+    if (this._transform === this._objectTransform) {
+      delete this._transform;
+      this._transform({name: 'startObject'}, null, doNothing);
+    }
+    this._transform({name: 'endObject'}, null, callback);
   }
 
   _transform(chunk, _, callback) {

--- a/tests/test_stringer.js
+++ b/tests/test_stringer.js
@@ -184,6 +184,12 @@ unit.add(module, [
 
     new ReadString('').pipe(parser);
   },
+  function test_stringer_json_stream_objects_as_object(t) {
+    // todo
+  },
+  function test_stringer_no_input_as_object(t) {
+    // todo
+  },
   function test_stringer_json_stream_primitives(t) {
     const async = t.startAsync('test_stringer_json_stream_primitives');
 


### PR DESCRIPTION
Hi Eugene! I just wanted to say that your library is awesome.

I've a request. Would it be possible for you to add the `makeObject` option for the Stringers since we already have the `makeArray` one? I've a situation where I need to process an array of elements into a map.

Thanks in advance!

```jsonc
[
  { "id": "first" },
  // ...
  { "id": "fifth" }
]
```

```jsonc
{
  "first": 0,
  // ...
  "fifth": 4
}
```

```js
let i = 0

new Chain([
  createReadStream(from),
  parser(),
  new StreamArray(),
  new Transform({
    objectMode: true,
    transform(ch, _, cb) {
      pushPair.call(this, ch.value.id, i)
      i += 1
      cb(null)
    }
  }),
  new Transform({
    objectMode: true,
    transform(ch, enc, cb) {
      this.push({ name: "startObject" })
      this._transform = transformPassThrough
      return this._transform(ch, enc, cb)
    },
    flush(cb) {
      if (this._transform === transformPassThrough) {
        this.push({ name: "endObject" })
      }
      cb(null)
    }
  }),
  new Stringer(),
  createWriteStream(to)
])

function transformPassThrough(ch, enc, cb) {
  this.push(ch, enc)
  cb(null)
}
```