### PR TITLE
Add partial `Map` support to assembler

### DIFF
--- a/src/assembler.js
+++ b/src/assembler.js
@@ -131,7 +131,11 @@ class Assembler extends EventEmitter {
       if (this.current instanceof Array) {
         this.current.push(value);
       } else {
-        this.current[this.key] = value;
+        if (this.current instanceof Map) {
+          this.current.set(this.key, value);
+        } else {
+          this.current[this.key] = value;
+        }
         this.key = null;
       }
     }

--- a/tests/test-assembler.mjs
+++ b/tests/test-assembler.mjs
@@ -182,3 +182,32 @@ test.asPromise('assembler: chain', (t, resolve, reject) => {
     });
   });
 });
+
+test('assembler: populates Map', t => {
+  const asm = assembler();
+
+  asm.consume({name: 'startObject'}); // { ...
+  asm.current = new Map();
+  asm.consume({name: 'keyValue', value: 'string'}); // 'string': 'foo'
+  asm.consume({name: 'stringValue', value: 'foo'});
+  asm.consume({name: 'keyValue', value: 'number'}); // 'number': 123
+  asm.consume({name: 'numberValue', value: '123'});
+  asm.consume({name: 'keyValue', value: 'null'}); // 'null': null
+  asm.consume({name: 'nullValue'});
+  asm.consume({name: 'keyValue', value: 'object'}); // 'object': []
+  asm.consume({name: 'startObject'});
+  asm.consume({name: 'endObject'});
+  asm.consume({name: 'keyValue', value: 'array'}); // 'array': []
+  asm.consume({name: 'startArray'});
+  asm.consume({name: 'endArray'});
+  asm.consume({name: 'endObject'}); // ... }
+
+  const map = asm.current;
+
+  t.ok(map instanceof Map);
+  t.strictEqual(map.get('string'), 'foo');
+  t.strictEqual(map.get('number'), 123);
+  t.strictEqual(map.get('null'), null);
+  t.deepEqual(map.get('object'), {});
+  t.deepEqual(map.get('array'), []);
+});


### PR DESCRIPTION
Allow Assembler customizations to replace Object instances with Map without affecting the rest of its functionality.  It makes it much more efficient when deserializing large "objects" that are functionally lookup tables, with minimal customization.

The mechanism for determining when replacement with Map is used is out-of-scope.  There are no new APIs added.

----

I have a use case where the parsed JSON consists primarily of large lookup tables (700+ entries per table):
```jsonc
{
  "modules": {
    "mod000": { /*...*/ },
    "mod001": { /*...*/ },
    //...
    "mod750": { /*...*/ }
  },
  "metadata": { /*...*/ }
}
```

The table is transformed to `Map` for actual usage, which is a somewhat awkward process.  With `Assembler` modified to understand `Map`, it becomes much simpler.

```ts
class ModuleTableAssembler extends Assembler {
  startObject() {
    super.startObject()
    if (useMap(this.stack)) {
      this.current = new Map();
    }
  }
}

const asm = new ModuleTableAssembler();
for await (const token of parser.iterator()) {
  asm.consume(token);
}
const moduleTable = asm.current;
```

Doing this with monkey patching is possible but very awkward due to the way `Assembler`'s internal methods are connected.  Extending `_saveValue()` to cover `Map` makes this basically trivial..